### PR TITLE
Update angular-gettext-tools dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "through2": "~0.4.1",
     "gulp-util": "~2.2.14",
-    "angular-gettext-tools": "~0.0.14",
+    "angular-gettext-tools": "~1.0.0",
     "lodash.isstring": "~2.4.1"
   },
   "devDependencies": {


### PR DESCRIPTION
You should use a tilde-match here, otherwise users of `gulp-angular-gettext` won't get bugfixes when a new version of `angular-gettext-tools` is released.
