### PR TITLE
Fix cheerio w/ new angular-gettext-tools version

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "through2": "~0.6.3",
     "gulp-util": "~3.0.2",
-    "angular-gettext-tools": "^2.0.1",
+    "angular-gettext-tools": "^2.1.2",
     "lodash.isstring": "~2.4.1"
   },
   "devDependencies": {


### PR DESCRIPTION
gulp-angular-gettext/node_modules/angular-gettext-tools/node_modules/cheerio/lib/cheerio.js:93
_.extend(Cheerio, require('./static'));
  ^
TypeError: undefined is not a function
    at Object.<anonymous> (gulp-angular-gettext/node_modules/angular-gettext-tools/node_modules/cheerio/lib/cheerio.js:93:3)
    at Module._compile (module.js:460:26)
    at Object.Module._extensions..js (module.js:478:10)
    at Module.load (module.js:355:32)
    at Function.Module._load (module.js:310:12)
    at Module.require (module.js:365:17)
    at require (module.js:384:17)
    at Object.<anonymous> (gulp-angular-gettext/node_modules/angular-gettext-tools/node_modules/cheerio/index.js:5:28)
    at Module._compile (module.js:460:26)
    at Object.Module._extensions..js (module.js:478:10)