### PR TITLE
Update angular-gettext-tools version number

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "through2": "~0.6.3",
     "gulp-util": "~3.0.2",
-    "angular-gettext-tools": "^2.0.1",
+    "angular-gettext-tools": "^2.1.11",
     "lodash.isstring": "~2.4.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Update angular-gettext-tools version number to the most recent one. The actual version of angular-gettext-tools fixes a few issues with corrupted parsing results.