### PR TITLE
Fix one pot per input file mode

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,4 @@
+root = true
+
+[*]
+end_of_line = lf

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ node_modules
 !.gitignore
 !.gitattributes
 !.travis.yml
+!.editorconfig

--- a/lib/extract.js
+++ b/lib/extract.js
@@ -21,8 +21,6 @@ module.exports = function (out, config) {
     this.emit('error', new gutil.PluginError(pluginName, 'Streaming not supported'));
   }.bind(this);
 
-  var extractor = new Extractor(config);
-
   if (!out) {
     // return a standard gulp stream
     return through.obj(function (file, enc, cb) {
@@ -36,6 +34,7 @@ module.exports = function (out, config) {
         return cb();
       }
 
+      var extractor = new Extractor(config);
       extractor.parse(file.relative, file.contents.toString());
       file.contents = new Buffer(extractor.toString());
 
@@ -50,6 +49,7 @@ module.exports = function (out, config) {
 
   // concatenate output, inspired by gulp-concat
 
+  var extractor = new Extractor(config);
   var firstFile = null;
 
   var bufferContents = function (file, encoding, cb) {

--- a/test/main.js
+++ b/test/main.js
@@ -186,6 +186,13 @@ describe('gulp-angular-gettext', function () {
             return;
           }
 
+          if (process.platform === 'win32') {
+            // Replace Unix path separators (i.e. '/') with Windows path separators (i.e. '\\') in pot fixture
+            pot = pot.split('\n').map(function (line) {
+              return /^#: /.test(line) ? line.replace(/\//g, '\\') : line;
+            }).join('\n');
+          }
+
           expect(file.contents.toString()).to.equal(pot);
 
           done();


### PR DESCRIPTION
Fixes #37 by using a different `Extractor` for each input file, when running in one-pot-per-input-file mode