### PR TITLE
Fix extracting from empty stream

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,4 @@
+root = true
+
+[*]
+end_of_line = lf

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ node_modules
 !.gitignore
 !.gitattributes
 !.travis.yml
+!.editorconfig

--- a/lib/extract.js
+++ b/lib/extract.js
@@ -74,14 +74,15 @@ module.exports = function (out, config) {
   };
 
   var flush = function (cb) {
-    this.push(new gutil.File({
-      // if you don't want to use the first file for the base directory, you can use gulp-rename to change it
-      cwd: firstFile.cwd,
-      base: firstFile.base,
-      path: path.join(firstFile.base, out),
-      contents: new Buffer(extractor.toString())
-    }));
-
+    if (firstFile) {
+      this.push(new gutil.File({
+        // if you don't want to use the first file for the base directory, you can use gulp-rename to change it
+        cwd: firstFile.cwd,
+        base: firstFile.base,
+        path: path.join(firstFile.base, out),
+        contents: new Buffer(extractor.toString())
+      }));
+    }
     cb();
   };
 

--- a/test/main.js
+++ b/test/main.js
@@ -186,6 +186,13 @@ describe('gulp-angular-gettext', function () {
             return;
           }
 
+          if (process.platform === 'win32') {
+            // Replace Unix path separators (i.e. '/') with Windows path separators (i.e. '\\') in pot fixture
+            pot = pot.split('\n').map(function (line) {
+              return /^#: /.test(line) ? line.replace(/\//g, '\\') : line;
+            }).join('\n');
+          }
+
           expect(file.contents.toString()).to.equal(pot);
 
           done();

--- a/test/main.js
+++ b/test/main.js
@@ -161,6 +161,20 @@ describe('gulp-angular-gettext', function () {
       stream.end();
     });
 
+    it('should work with no input files', function (done) {
+      var files = [];
+      var stream = extract('out.pot');
+      stream.on('error', done);
+      stream.on('data', function (file) {
+        files.push(file);
+      });
+      stream.on('end', function () {
+        expect(files.length).to.equal(0);
+        done();
+      });
+      stream.end();
+    });
+
     it('should support relative paths properly', function (done) {
       var partial1 = new gutil.File({
         cwd: __dirname,


### PR DESCRIPTION
Fixes #39

Changes the `extract` stream to only push the output vinyl file if there were any files in the input vinyl stream.

In this way, we avoid reading `firstFile.cwd` and `firstFile.base`, which would throw an error since `firstFile` is still `null`.

@gabegorelick Please review :smiley:  