### PR TITLE
Remove dependency on gulp-util, use vinyl, plugin-error instead

### DIFF
--- a/lib/compile.js
+++ b/lib/compile.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var Compiler = require('angular-gettext-tools').Compiler;
-var gutil = require('gulp-util');
+var PluginError = require('plugin-error');
 var through = require('through2');
 var path = require('path');
 
@@ -17,7 +17,7 @@ module.exports = function (options) {
     }
 
     if (file.isStream()) {
-      this.emit('error', new gutil.PluginError(pluginName, 'Streaming not supported'));
+      this.emit('error', new PluginError(pluginName, 'Streaming not supported'));
       return cb();
     }
 

--- a/lib/extract.js
+++ b/lib/extract.js
@@ -1,7 +1,8 @@
 'use strict';
 
 var Extractor = require('angular-gettext-tools').Extractor;
-var gutil = require('gulp-util');
+var Vinyl = require('vinyl');
+var PluginError = require('plugin-error');
 var through = require('through2');
 var path = require('path');
 var isString = require('lodash.isstring');
@@ -18,7 +19,7 @@ module.exports = function (out, config) {
   }
 
   var emitStreamingError = function () {
-    this.emit('error', new gutil.PluginError(pluginName, 'Streaming not supported'));
+    this.emit('error', new PluginError(pluginName, 'Streaming not supported'));
   }.bind(this);
 
   var extractor = new Extractor(config);
@@ -74,7 +75,7 @@ module.exports = function (out, config) {
   };
 
   var flush = function (cb) {
-    this.push(new gutil.File({
+    this.push(new Vinyl({
       // if you don't want to use the first file for the base directory, you can use gulp-rename to change it
       cwd: firstFile.cwd,
       base: firstFile.base,

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
   "main": "index.js",
   "dependencies": {
     "through2": "^2.0.1",
-    "gulp-util": "^3.0.7",
+    "vinyl": "^2.2.0",
+    "plugin-error": "^1.0.1",
     "angular-gettext-tools": "^2.2.0",
     "lodash.isstring": "^4.17.5"
   },

--- a/test/main.js
+++ b/test/main.js
@@ -2,7 +2,7 @@
 
 var compile = require('../').compile;
 var extract = require('../').extract;
-var gutil = require('gulp-util');
+var Vinyl = require('vinyl');
 var expect = require('chai').expect;
 var fs = require('fs');
 var path = require('path');
@@ -12,7 +12,7 @@ var fixturesDir = path.join(__dirname, 'fixtures');
 var anotherDir = path.join(__dirname, 'another');
 
 var createFixtureFile = function (filename, content) {
-  return new gutil.File({
+  return new Vinyl({
     cwd: __dirname,
     base: fixturesDir,
     path: path.join(fixturesDir, filename),
@@ -162,13 +162,13 @@ describe('gulp-angular-gettext', function () {
     });
 
     it('should support relative paths properly', function (done) {
-      var partial1 = new gutil.File({
+      var partial1 = new Vinyl({
         cwd: __dirname,
         base: anotherDir,
         path: path.join(fixturesDir, 'partial1.html'),
         contents: new Buffer('<div translate>Hello</div>')
       });
-      var partial2 = new gutil.File({
+      var partial2 = new vinyl({
         cwd: __dirname,
         base: anotherDir,
         path: path.join(fixturesDir, 'partial2.html'),


### PR DESCRIPTION
Fix #44

Note that the recent merge to "fix" the version of `lodash.isstring` broke builds; its current version is 4.0.1 so either someone updates the lodash.isstring package or we change the dependency to `"lodash": "4.17.11"`.