### PR TITLE
Remove lodash

### DIFF
--- a/lib/extract.js
+++ b/lib/extract.js
@@ -4,13 +4,12 @@ var Extractor = require('angular-gettext-tools').Extractor;
 var gutil = require('gulp-util');
 var through = require('through2');
 var path = require('path');
-var isString = require('lodash.isstring');
 
 var pluginName = require('../package.json').name;
 
 module.exports = function (out, config) {
   if (arguments.length === 1) {
-    if (!isString(out)) {
+    if (typeof out !== 'string') {
       // out is optional
       config = arguments[0];
       out = null;

--- a/package.json
+++ b/package.json
@@ -28,8 +28,7 @@
   "dependencies": {
     "through2": "^2.0.1",
     "gulp-util": "^3.0.7",
-    "angular-gettext-tools": "^2.2.0",
-    "lodash.isstring": "^4.17.5"
+    "angular-gettext-tools": "^2.2.0"
   },
   "devDependencies": {
     "chai": "^3.5.0",


### PR DESCRIPTION
It's not worth the overhead of keeping it up to date.

This change may break callers passing in funky String objects, but just don't do that.